### PR TITLE
Update for OS X El Capitan

### DIFF
--- a/install.py
+++ b/install.py
@@ -30,6 +30,11 @@ if not vals["XT"] :
   macxt = "/usr/X11R6/bin/xterm"
   if os.path.isfile(macxt) :
     vals["XT"] = macxt
+  # hack for OS X El Capitan
+  else :
+    macxt = "/usr/X11/bin/xterm"
+    if os.path.isfile(macxt) :
+      vals["XT"] = macxt
 
 globals().update(vals)
 


### PR DESCRIPTION
This checks an additional path for `xterm` to be compatible with OS X El Capitan (10.11). People will need to rerun the install script after updating to El Cap and pulling from TagTime master. 